### PR TITLE
chore: release v0.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,27 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [0.0.3](https://github.com/jcape/rxegy/compare/rxegy-v0.0.2...rxegy-v0.0.3) - 2025-02-27
+
+### Added
+
+- implement some session api, fix send/sync issue
+- wire up session and builder
+- start work on session objects.
+
+### Fixed
+
+- fix clippy warnings
+- add more error codes, pin session
+
+### Other
+
+- release automation on pr merge
+- refactor session handling into a good place
+- add markdownlint vsc extension
+- fix cargo install of binstall
+- remove broken binstall feature
+
 ## [0.0.2](https://github.com/jcape/rxegy/compare/rxegy-v0.0.1...rxegy-v0.0.2) - 2025-02-24
 
 ### Other

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = [".", "sys"]
 
 [workspace.package]
-version = "0.0.2"
+version = "0.0.3"
 authors = ["James Cape <jamescape777@gmail.com>"]
 edition = "2024"
 license = "Apache-2.0"
@@ -27,7 +27,7 @@ anyhow = "1.0.96"
 displaydoc = "0.2.1"
 paste = "1.0.15"
 ref-cast = "1.0"
-rxegy-sys = { path = "./sys", version = "0.0.2" }
+rxegy-sys = { path = "./sys", version = "0.0.3" }
 secrecy = "0.10.3"
 thiserror = "2.0.11"
 


### PR DESCRIPTION



## 🤖 New release

* `rxegy-sys`: 0.0.2 -> 0.0.3
* `rxegy`: 0.0.2 -> 0.0.3

<details><summary><i><b>Changelog</b></i></summary><p>

## `rxegy-sys`

<blockquote>

## [0.0.2](https://github.com/jcape/rxegy/compare/rxegy-sys-v0.0.1...rxegy-sys-v0.0.2) - 2025-02-24

### Other

- fix chiclets in readme
</blockquote>

## `rxegy`

<blockquote>

## [0.0.3](https://github.com/jcape/rxegy/compare/rxegy-v0.0.2...rxegy-v0.0.3) - 2025-02-27

### Added

- implement some session api, fix send/sync issue
- wire up session and builder
- start work on session objects.

### Fixed

- fix clippy warnings
- add more error codes, pin session

### Other

- release automation on pr merge
- refactor session handling into a good place
- add markdownlint vsc extension
- fix cargo install of binstall
- remove broken binstall feature
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).