### PR TITLE
chore: release v0.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,28 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [0.0.3](https://github.com/jcape/rxegy/compare/rxegy-v0.0.2...rxegy-v0.0.3) - 2025-02-27
+
+### Added
+
+- implement some session api, fix send/sync issue
+- wire up session and builder
+- start work on session objects.
+
+### Fixed
+
+- semver-checks installed from source
+- fix clippy warnings
+- add more error codes, pin session
+
+### Other
+
+- release automation on pr merge
+- refactor session handling into a good place
+- add markdownlint vsc extension
+- fix cargo install of binstall
+- remove broken binstall feature
+
 ## [0.0.2](https://github.com/jcape/rxegy/compare/rxegy-v0.0.1...rxegy-v0.0.2) - 2025-02-24
 
 ### Other

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = [".", "sys"]
 
 [workspace.package]
-version = "0.0.2"
+version = "0.0.3"
 authors = ["James Cape <jamescape777@gmail.com>"]
 edition = "2024"
 license = "Apache-2.0"
@@ -27,7 +27,7 @@ anyhow = "1.0.96"
 displaydoc = "0.2.1"
 paste = "1.0.15"
 ref-cast = "1.0"
-rxegy-sys = { path = "./sys", version = "0.0.2" }
+rxegy-sys = { path = "./sys", version = "0.0.3" }
 secrecy = "0.10.3"
 thiserror = "2.0.11"
 


### PR DESCRIPTION



## 🤖 New release

* `rxegy-sys`: 0.0.2 -> 0.0.3
* `rxegy`: 0.0.2 -> 0.0.3 (⚠ API breaking changes)

### ⚠ `rxegy` breaking changes

```text
--- failure auto_trait_impl_removed: auto trait no longer implemented ---

Description:
A public type has stopped implementing one or more auto traits. This can break downstream code that depends on the traits being implemented.
        ref: https://doc.rust-lang.org/reference/special-types-and-traits.html#auto-traits
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.39.0/src/lints/auto_trait_impl_removed.ron

Failed in:
  type Error is no longer UnwindSafe, in /tmp/.tmpVk3cbp/rxegy/src/error.rs:11
  type Error is no longer RefUnwindSafe, in /tmp/.tmpVk3cbp/rxegy/src/error.rs:11

--- failure derive_trait_impl_removed: built-in derived trait no longer implemented ---

Description:
A public type has stopped deriving one or more traits. This can break downstream code that depends on those types implementing those traits.
        ref: https://doc.rust-lang.org/reference/attributes/derive.html#derive
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.39.0/src/lints/derive_trait_impl_removed.ron

Failed in:
  type Error no longer derives Copy, in /tmp/.tmpVk3cbp/rxegy/src/error.rs:11
  type Error no longer derives Clone, in /tmp/.tmpVk3cbp/rxegy/src/error.rs:11
  type Error no longer derives Eq, in /tmp/.tmpVk3cbp/rxegy/src/error.rs:11
  type Error no longer derives Hash, in /tmp/.tmpVk3cbp/rxegy/src/error.rs:11
  type Error no longer derives Ord, in /tmp/.tmpVk3cbp/rxegy/src/error.rs:11
  type Error no longer derives PartialEq, in /tmp/.tmpVk3cbp/rxegy/src/error.rs:11
  type Error no longer derives PartialOrd, in /tmp/.tmpVk3cbp/rxegy/src/error.rs:11
  type ExegyError no longer derives Copy, in /tmp/.tmpVk3cbp/rxegy/src/error.rs:72
  type ExegyError no longer derives Clone, in /tmp/.tmpVk3cbp/rxegy/src/error.rs:72
  type ExegyError no longer derives Eq, in /tmp/.tmpVk3cbp/rxegy/src/error.rs:72
  type ExegyError no longer derives Hash, in /tmp/.tmpVk3cbp/rxegy/src/error.rs:72
  type ExegyError no longer derives Ord, in /tmp/.tmpVk3cbp/rxegy/src/error.rs:72
  type ExegyError no longer derives PartialEq, in /tmp/.tmpVk3cbp/rxegy/src/error.rs:72
  type ExegyError no longer derives PartialOrd, in /tmp/.tmpVk3cbp/rxegy/src/error.rs:72

--- failure enum_missing: pub enum removed or renamed ---

Description:
A publicly-visible enum cannot be imported by its prior path. A `pub use` may have been removed, or the enum itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.39.0/src/lints/enum_missing.ron

Failed in:
  enum rxegy::session::Kind, previously in file /tmp/.tmp3NoDPl/rxegy/src/session.rs:8

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.39.0/src/lints/enum_variant_added.ron

Failed in:
  variant Error:ObjectUnknown in /tmp/.tmpVk3cbp/rxegy/src/error.rs:26
  variant Error:Io in /tmp/.tmpVk3cbp/rxegy/src/error.rs:30
  variant Error:EmbeddedNull in /tmp/.tmpVk3cbp/rxegy/src/error.rs:34
  variant Error:NoNullTerm in /tmp/.tmpVk3cbp/rxegy/src/error.rs:38
  variant Error:SessionPanic in /tmp/.tmpVk3cbp/rxegy/src/error.rs:42
  variant Error:NoCallbacksSet in /tmp/.tmpVk3cbp/rxegy/src/error.rs:46
  variant Error:InvalidUtf8 in /tmp/.tmpVk3cbp/rxegy/src/error.rs:50
  variant Error:SessionNotInitialized in /tmp/.tmpVk3cbp/rxegy/src/error.rs:54
  variant Error:NullObject in /tmp/.tmpVk3cbp/rxegy/src/error.rs:58
  variant Error:UnexpectedKind in /tmp/.tmpVk3cbp/rxegy/src/error.rs:62
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `rxegy-sys`

<blockquote>

## [0.0.2](https://github.com/jcape/rxegy/compare/rxegy-sys-v0.0.1...rxegy-sys-v0.0.2) - 2025-02-24

### Other

- fix chiclets in readme
</blockquote>

## `rxegy`

<blockquote>

## [0.0.3](https://github.com/jcape/rxegy/compare/rxegy-v0.0.2...rxegy-v0.0.3) - 2025-02-27

### Added

- implement some session api, fix send/sync issue
- wire up session and builder
- start work on session objects.

### Fixed

- semver-checks installed from source
- fix clippy warnings
- add more error codes, pin session

### Other

- release automation on pr merge
- refactor session handling into a good place
- add markdownlint vsc extension
- fix cargo install of binstall
- remove broken binstall feature
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).