### PR TITLE
chore: release v0.0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [0.0.4](https://github.com/jcape/rxegy/compare/rxegy-v0.0.3...rxegy-v0.0.4) - 2025-02-28
+
+### Added
+
+- [**breaking**] support common event fields
+
 ## [0.0.3](https://github.com/jcape/rxegy/compare/rxegy-v0.0.2...rxegy-v0.0.3) - 2025-02-27
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = [".", "sys"]
 
 [workspace.package]
-version = "0.0.3"
+version = "0.0.4"
 authors = ["James Cape <jamescape777@gmail.com>"]
 edition = "2024"
 license = "Apache-2.0"
@@ -27,7 +27,7 @@ anyhow = "1.0.96"
 displaydoc = "0.2.1"
 paste = "1.0.15"
 ref-cast = "1.0"
-rxegy-sys = { path = "./sys", version = "0.0.3" }
+rxegy-sys = { path = "./sys", version = "0.0.4" }
 secrecy = "0.10.3"
 thiserror = "2.0.11"
 


### PR DESCRIPTION



## 🤖 New release

* `rxegy-sys`: 0.0.3 -> 0.0.4
* `rxegy`: 0.0.3 -> 0.0.4 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `rxegy-sys`

<blockquote>

## [0.0.2](https://github.com/jcape/rxegy/compare/rxegy-sys-v0.0.1...rxegy-sys-v0.0.2) - 2025-02-24

### Other

- fix chiclets in readme
</blockquote>

## `rxegy`

<blockquote>

## [0.0.4](https://github.com/jcape/rxegy/compare/rxegy-v0.0.3...rxegy-v0.0.4) - 2025-02-28

### Added

- [**breaking**] support common event fields
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).