### PR TITLE
chore: release v0.0.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,29 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [0.0.5](https://github.com/jcape/rxegy/compare/rxegy-v0.0.4...rxegy-v0.0.5) - 2025-03-03
+
+### Added
+
+- initial catalog impl
+- add display impls for key and symbol
+- use arc<callbacks> for shared callbacks
+- finish us equites mics, make xx enum a feed
+- more work on keylist catalog
+
+### Fixed
+
+- clippy warnings
+- don't lose track of session after the first callback
+- functional session creation / connection
+
+### Other
+
+- [**breaking**] clean up bindgen usage, remove system types
+- use custom dockerfile to install libclang
+- use local cargo/pre-commit cache.
+- move cargo installs to post-create command.
+
 ## [0.0.4](https://github.com/jcape/rxegy/compare/rxegy-v0.0.3...rxegy-v0.0.4) - 2025-02-28
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = [".", "sys"]
 
 [workspace.package]
-version = "0.0.4"
+version = "0.0.5"
 authors = ["James Cape <jamescape777@gmail.com>"]
 edition = "2024"
 license = "Apache-2.0"
@@ -27,7 +27,7 @@ anyhow = "1"
 displaydoc = "0.2.1"
 paste = "1"
 ref-cast = "1"
-rxegy-sys = { path = "./sys", version = "0.0.4" }
+rxegy-sys = { path = "./sys", version = "0.0.5" }
 secrecy = "0.10"
 thiserror = "2"
 tracing = "0.1"

--- a/sys/CHANGELOG.md
+++ b/sys/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.5](https://github.com/jcape/rxegy/compare/rxegy-sys-v0.0.4...rxegy-sys-v0.0.5) - 2025-03-03
+
+### Added
+
+- generate ffi for xcapi formatting/converting
+
+### Fixed
+
+- manually implement defualt for format control
+
+### Other
+
+- [**breaking**] clean up bindgen usage, remove system types
+
 ## [0.0.2](https://github.com/jcape/rxegy/compare/rxegy-sys-v0.0.1...rxegy-sys-v0.0.2) - 2025-02-24
 
 ### Other


### PR DESCRIPTION



## 🤖 New release

* `rxegy-sys`: 0.0.4 -> 0.0.5 (⚠ API breaking changes)
* `rxegy`: 0.0.4 -> 0.0.5 (⚠ API breaking changes)

### ⚠ `rxegy-sys` breaking changes

```text
--- failure pub_module_level_const_missing: pub module-level const is missing ---

Description:
A public const is missing, renamed, or changed from const to static.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.39.0/src/lints/pub_module_level_const_missing.ron

Failed in:
  INT16_MAX in file /tmp/.tmpACdo3L/rxegy-sys/src/gen.inc.rs:5374
  __STDC_IEC_559_COMPLEX__ in file /tmp/.tmpACdo3L/rxegy-sys/src/gen.inc.rs:5341
  UINT_FAST8_MAX in file /tmp/.tmpACdo3L/rxegy-sys/src/gen.inc.rs:5394
  __INO_T_MATCHES_INO64_T in file /tmp/.tmpACdo3L/rxegy-sys/src/gen.inc.rs:5361
  _ATFILE_SOURCE in file /tmp/.tmpACdo3L/rxegy-sys/src/gen.inc.rs:5328
  INT_LEAST32_MIN in file /tmp/.tmpACdo3L/rxegy-sys/src/gen.inc.rs:5381
  __glibc_c99_flexarr_available in file /tmp/.tmpACdo3L/rxegy-sys/src/gen.inc.rs:5348
  PTRDIFF_MAX in file /tmp/.tmpACdo3L/rxegy-sys/src/gen.inc.rs:5401
  __GLIBC_USE_ISOC2X in file /tmp/.tmpACdo3L/rxegy-sys/src/gen.inc.rs:5315
  _BITS_STDINT_INTN_H in file /tmp/.tmpACdo3L/rxegy-sys/src/gen.inc.rs:5368
  __USE_FORTIFY_LEVEL in file /tmp/.tmpACdo3L/rxegy-sys/src/gen.inc.rs:5335
  INT_FAST8_MIN in file /tmp/.tmpACdo3L/rxegy-sys/src/gen.inc.rs:5388
  __GLIBC_USE_IEC_60559_FUNCS_EXT in file /tmp/.tmpACdo3L/rxegy-sys/src/gen.inc.rs:5355
  __USE_POSIX in file /tmp/.tmpACdo3L/rxegy-sys/src/gen.inc.rs:5322
  INT32_MAX in file /tmp/.tmpACdo3L/rxegy-sys/src/gen.inc.rs:5375
  __STDC_IEC_60559_COMPLEX__ in file /tmp/.tmpACdo3L/rxegy-sys/src/gen.inc.rs:5342
  UINT_FAST16_MAX in file /tmp/.tmpACdo3L/rxegy-sys/src/gen.inc.rs:5395
  __RLIM_T_MATCHES_RLIM64_T in file /tmp/.tmpACdo3L/rxegy-sys/src/gen.inc.rs:5362
  __WORDSIZE in file /tmp/.tmpACdo3L/rxegy-sys/src/gen.inc.rs:5329
  INT_LEAST8_MAX in file /tmp/.tmpACdo3L/rxegy-sys/src/gen.inc.rs:5382
  __LDOUBLE_REDIRECTS_TO_FLOAT128_ABI in file /tmp/.tmpACdo3L/rxegy-sys/src/gen.inc.rs:5349
  SIG_ATOMIC_MIN in file /tmp/.tmpACdo3L/rxegy-sys/src/gen.inc.rs:5402
  __USE_ISOC11 in file /tmp/.tmpACdo3L/rxegy-sys/src/gen.inc.rs:5316
  _BITS_STDINT_UINTN_H in file /tmp/.tmpACdo3L/rxegy-sys/src/gen.inc.rs:5369
  __GLIBC_USE_DEPRECATED_GETS in file /tmp/.tmpACdo3L/rxegy-sys/src/gen.inc.rs:5336
  INT_FAST16_MIN in file /tmp/.tmpACdo3L/rxegy-sys/src/gen.inc.rs:5389
  __GLIBC_USE_IEC_60559_FUNCS_EXT_C2X in file /tmp/.tmpACdo3L/rxegy-sys/src/gen.inc.rs:5356
  __USE_POSIX2 in file /tmp/.tmpACdo3L/rxegy-sys/src/gen.inc.rs:5323
  UINT8_MAX in file /tmp/.tmpACdo3L/rxegy-sys/src/gen.inc.rs:5376
  __STDC_ISO_10646__ in file /tmp/.tmpACdo3L/rxegy-sys/src/gen.inc.rs:5343
  UINT_FAST32_MAX in file /tmp/.tmpACdo3L/rxegy-sys/src/gen.inc.rs:5396
  __STATFS_MATCHES_STATFS64 in file /tmp/.tmpACdo3L/rxegy-sys/src/gen.inc.rs:5363
  __WORDSIZE_TIME64_COMPAT32 in file /tmp/.tmpACdo3L/rxegy-sys/src/gen.inc.rs:5330
  INT_LEAST16_MAX in file /tmp/.tmpACdo3L/rxegy-sys/src/gen.inc.rs:5383
  __HAVE_GENERIC_SELECTION in file /tmp/.tmpACdo3L/rxegy-sys/src/gen.inc.rs:5350
  SIG_ATOMIC_MAX in file /tmp/.tmpACdo3L/rxegy-sys/src/gen.inc.rs:5403
  __USE_ISOC99 in file /tmp/.tmpACdo3L/rxegy-sys/src/gen.inc.rs:5317
  INT8_MIN in file /tmp/.tmpACdo3L/rxegy-sys/src/gen.inc.rs:5370
  __GLIBC_USE_DEPRECATED_SCANF in file /tmp/.tmpACdo3L/rxegy-sys/src/gen.inc.rs:5337
  INT_FAST32_MIN in file /tmp/.tmpACdo3L/rxegy-sys/src/gen.inc.rs:5390
  __GLIBC_USE_IEC_60559_TYPES_EXT in file /tmp/.tmpACdo3L/rxegy-sys/src/gen.inc.rs:5357
  __USE_POSIX199309 in file /tmp/.tmpACdo3L/rxegy-sys/src/gen.inc.rs:5324
  UINT16_MAX in file /tmp/.tmpACdo3L/rxegy-sys/src/gen.inc.rs:5377
  __GNU_LIBRARY__ in file /tmp/.tmpACdo3L/rxegy-sys/src/gen.inc.rs:5344
  INTPTR_MIN in file /tmp/.tmpACdo3L/rxegy-sys/src/gen.inc.rs:5397
  __KERNEL_OLD_TIMEVAL_MATCHES_TIMEVAL64 in file /tmp/.tmpACdo3L/rxegy-sys/src/gen.inc.rs:5364
  __SYSCALL_WORDSIZE in file /tmp/.tmpACdo3L/rxegy-sys/src/gen.inc.rs:5331
  INT_LEAST32_MAX in file /tmp/.tmpACdo3L/rxegy-sys/src/gen.inc.rs:5384
  __GLIBC_USE_LIB_EXT2 in file /tmp/.tmpACdo3L/rxegy-sys/src/gen.inc.rs:5351
  SIZE_MAX in file /tmp/.tmpACdo3L/rxegy-sys/src/gen.inc.rs:5404
  __USE_ISOC95 in file /tmp/.tmpACdo3L/rxegy-sys/src/gen.inc.rs:5318
  INT16_MIN in file /tmp/.tmpACdo3L/rxegy-sys/src/gen.inc.rs:5371
  _STDC_PREDEF_H in file /tmp/.tmpACdo3L/rxegy-sys/src/gen.inc.rs:5338
  INT_FAST8_MAX in file /tmp/.tmpACdo3L/rxegy-sys/src/gen.inc.rs:5391
  _BITS_TYPES_H in file /tmp/.tmpACdo3L/rxegy-sys/src/gen.inc.rs:5358
  __USE_POSIX199506 in file /tmp/.tmpACdo3L/rxegy-sys/src/gen.inc.rs:5325
  UINT32_MAX in file /tmp/.tmpACdo3L/rxegy-sys/src/gen.inc.rs:5378
  __GLIBC__ in file /tmp/.tmpACdo3L/rxegy-sys/src/gen.inc.rs:5345
  INTPTR_MAX in file /tmp/.tmpACdo3L/rxegy-sys/src/gen.inc.rs:5398
  _STDINT_H in file /tmp/.tmpACdo3L/rxegy-sys/src/gen.inc.rs:5312
  __FD_SETSIZE in file /tmp/.tmpACdo3L/rxegy-sys/src/gen.inc.rs:5365
  __TIMESIZE in file /tmp/.tmpACdo3L/rxegy-sys/src/gen.inc.rs:5332
  UINT_LEAST8_MAX in file /tmp/.tmpACdo3L/rxegy-sys/src/gen.inc.rs:5385
  __GLIBC_USE_IEC_60559_BFP_EXT in file /tmp/.tmpACdo3L/rxegy-sys/src/gen.inc.rs:5352
  WINT_MIN in file /tmp/.tmpACdo3L/rxegy-sys/src/gen.inc.rs:5405
  __USE_POSIX_IMPLICITLY in file /tmp/.tmpACdo3L/rxegy-sys/src/gen.inc.rs:5319
  INT32_MIN in file /tmp/.tmpACdo3L/rxegy-sys/src/gen.inc.rs:5372
  __STDC_IEC_559__ in file /tmp/.tmpACdo3L/rxegy-sys/src/gen.inc.rs:5339
  INT_FAST16_MAX in file /tmp/.tmpACdo3L/rxegy-sys/src/gen.inc.rs:5392
  _BITS_TYPESIZES_H in file /tmp/.tmpACdo3L/rxegy-sys/src/gen.inc.rs:5359
  __USE_XOPEN2K in file /tmp/.tmpACdo3L/rxegy-sys/src/gen.inc.rs:5326
  INT_LEAST8_MIN in file /tmp/.tmpACdo3L/rxegy-sys/src/gen.inc.rs:5379
  __GLIBC_MINOR__ in file /tmp/.tmpACdo3L/rxegy-sys/src/gen.inc.rs:5346
  UINTPTR_MAX in file /tmp/.tmpACdo3L/rxegy-sys/src/gen.inc.rs:5399
  _FEATURES_H in file /tmp/.tmpACdo3L/rxegy-sys/src/gen.inc.rs:5313
  _BITS_TIME64_H in file /tmp/.tmpACdo3L/rxegy-sys/src/gen.inc.rs:5366
  __USE_MISC in file /tmp/.tmpACdo3L/rxegy-sys/src/gen.inc.rs:5333
  UINT_LEAST16_MAX in file /tmp/.tmpACdo3L/rxegy-sys/src/gen.inc.rs:5386
  __GLIBC_USE_IEC_60559_BFP_EXT_C2X in file /tmp/.tmpACdo3L/rxegy-sys/src/gen.inc.rs:5353
  WINT_MAX in file /tmp/.tmpACdo3L/rxegy-sys/src/gen.inc.rs:5406
  _POSIX_SOURCE in file /tmp/.tmpACdo3L/rxegy-sys/src/gen.inc.rs:5320
  INT8_MAX in file /tmp/.tmpACdo3L/rxegy-sys/src/gen.inc.rs:5373
  __STDC_IEC_60559_BFP__ in file /tmp/.tmpACdo3L/rxegy-sys/src/gen.inc.rs:5340
  INT_FAST32_MAX in file /tmp/.tmpACdo3L/rxegy-sys/src/gen.inc.rs:5393
  __OFF_T_MATCHES_OFF64_T in file /tmp/.tmpACdo3L/rxegy-sys/src/gen.inc.rs:5360
  __USE_XOPEN2K8 in file /tmp/.tmpACdo3L/rxegy-sys/src/gen.inc.rs:5327
  INT_LEAST16_MIN in file /tmp/.tmpACdo3L/rxegy-sys/src/gen.inc.rs:5380
  _SYS_CDEFS_H in file /tmp/.tmpACdo3L/rxegy-sys/src/gen.inc.rs:5347
  PTRDIFF_MIN in file /tmp/.tmpACdo3L/rxegy-sys/src/gen.inc.rs:5400
  _DEFAULT_SOURCE in file /tmp/.tmpACdo3L/rxegy-sys/src/gen.inc.rs:5314
  _BITS_WCHAR_H in file /tmp/.tmpACdo3L/rxegy-sys/src/gen.inc.rs:5367
  __USE_ATFILE in file /tmp/.tmpACdo3L/rxegy-sys/src/gen.inc.rs:5334
  UINT_LEAST32_MAX in file /tmp/.tmpACdo3L/rxegy-sys/src/gen.inc.rs:5387
  __GLIBC_USE_IEC_60559_EXT in file /tmp/.tmpACdo3L/rxegy-sys/src/gen.inc.rs:5354
  _POSIX_C_SOURCE in file /tmp/.tmpACdo3L/rxegy-sys/src/gen.inc.rs:5321

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.39.0/src/lints/struct_missing.ron

Failed in:
  struct rxegy_sys::max_align_t, previously in file /tmp/.tmpACdo3L/rxegy-sys/src/gen.inc.rs:200
  struct rxegy_sys::__fsid_t, previously in file /tmp/.tmpACdo3L/rxegy-sys/src/gen.inc.rs:194
```

### ⚠ `rxegy` breaking changes

```text
--- failure enum_missing: pub enum removed or renamed ---

Description:
A publicly-visible enum cannot be imported by its prior path. A `pub use` may have been removed, or the enum itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.39.0/src/lints/enum_missing.ron

Failed in:
  enum rxegy::keylist::catalog::Event, previously in file /tmp/.tmpACdo3L/rxegy/src/keylist/catalog.rs:53

--- failure enum_tuple_variant_changed_kind: An enum tuple variant changed kind ---

Description:
A public enum's exhaustive tuple variant has changed to a different kind of enum variant, breaking possible instantiations and patterns.
        ref: https://doc.rust-lang.org/reference/items/enumerations.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.39.0/src/lints/enum_tuple_variant_changed_kind.ron

Failed in:
  variant Error::NoNullTerm in /tmp/.tmp30uIYJ/rxegy/src/error.rs:39

--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.39.0/src/lints/inherent_method_missing.ron

Failed in:
  Session::heartbeat_affinity, previously in file /tmp/.tmpACdo3L/rxegy/src/session.rs:298
  Builder::affinity, previously in file /tmp/.tmpACdo3L/rxegy/src/session.rs:565
  Builder::priority, previously in file /tmp/.tmpACdo3L/rxegy/src/session.rs:575
  Builder::heartbeat_affinity, previously in file /tmp/.tmpACdo3L/rxegy/src/session.rs:606
  Builder::heartbeat_priority, previously in file /tmp/.tmpACdo3L/rxegy/src/session.rs:616

--- failure method_requires_different_generic_type_params: method now requires a different number of generic type parameters ---

Description:
A method now requires a different number of generic type parameters than it used to. Uses of this method that supplied the previous number of generic types will be broken.
        ref: https://doc.rust-lang.org/reference/items/generics.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.39.0/src/lints/method_requires_different_generic_type_params.ron

Failed in:
  rxegy::session::Builder::username takes 0 generic types instead of 1, in /tmp/.tmp30uIYJ/rxegy/src/session.rs:522
  rxegy::session::Builder::add_server takes 0 generic types instead of 1, in /tmp/.tmp30uIYJ/rxegy/src/session.rs:552
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `rxegy-sys`

<blockquote>

## [0.0.5](https://github.com/jcape/rxegy/compare/rxegy-sys-v0.0.4...rxegy-sys-v0.0.5) - 2025-03-03

### Added

- generate ffi for xcapi formatting/converting

### Fixed

- manually implement defualt for format control

### Other

- [**breaking**] clean up bindgen usage, remove system types
</blockquote>

## `rxegy`

<blockquote>

## [0.0.5](https://github.com/jcape/rxegy/compare/rxegy-v0.0.4...rxegy-v0.0.5) - 2025-03-03

### Added

- initial catalog impl
- add display impls for key and symbol
- use arc<callbacks> for shared callbacks
- finish us equites mics, make xx enum a feed
- more work on keylist catalog

### Fixed

- clippy warnings
- don't lose track of session after the first callback
- functional session creation / connection

### Other

- [**breaking**] clean up bindgen usage, remove system types
- use custom dockerfile to install libclang
- use local cargo/pre-commit cache.
- move cargo installs to post-create command.
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).