### PR TITLE
chore: release v0.0.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [0.0.6](https://github.com/jcape/rxegy/compare/rxegy-v0.0.5...rxegy-v0.0.6) - 2025-03-03
+
+### Added
+
+- start work on equity streaming.
+
+### Fixed
+
+- disable markdownlint pre-commit hook
+
 ## [0.0.5](https://github.com/jcape/rxegy/compare/rxegy-v0.0.4...rxegy-v0.0.5) - 2025-03-03
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = [".", "sys"]
 
 [workspace.package]
-version = "0.0.5"
+version = "0.0.6"
 authors = ["James Cape <jamescape777@gmail.com>"]
 edition = "2024"
 license = "Apache-2.0"
@@ -27,7 +27,7 @@ anyhow = "1"
 displaydoc = "0.2.1"
 paste = "1"
 ref-cast = "1"
-rxegy-sys = { path = "./sys", version = "0.0.5" }
+rxegy-sys = { path = "./sys", version = "0.0.6" }
 secrecy = "0.10"
 thiserror = "2"
 tracing = "0.1"


### PR DESCRIPTION



## 🤖 New release

* `rxegy-sys`: 0.0.5 -> 0.0.6
* `rxegy`: 0.0.5 -> 0.0.6 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `rxegy-sys`

<blockquote>

## [0.0.5](https://github.com/jcape/rxegy/compare/rxegy-sys-v0.0.4...rxegy-sys-v0.0.5) - 2025-03-03

### Added

- generate ffi for xcapi formatting/converting

### Fixed

- manually implement defualt for format control

### Other

- [**breaking**] clean up bindgen usage, remove system types
</blockquote>

## `rxegy`

<blockquote>

## [0.0.6](https://github.com/jcape/rxegy/compare/rxegy-v0.0.5...rxegy-v0.0.6) - 2025-03-03

### Added

- start work on equity streaming.

### Fixed

- disable markdownlint pre-commit hook
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).